### PR TITLE
Escape apostrophe in mailto link

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,12 +91,12 @@
     <p><a target="_blank" rel="noopener" href="https://ifttt.com" title="IFTTT">IFTTT</a> is an app I co-founded that lets you connect all the things in your life, on your terms.</p>
     <p>Today I help startups launch, pivot, and grow their business.</p>
     <p>Often as a fractional or interim leader. Especially within media technology and developer tools.</p>
-    <p>Feel free to <a target="_blank" rel="noopener" href="mailto:alexander.tibbets@gmail.com?subject=%F0%9F%91%8B%20Let's%20connect%20and%20talk%20shop" title="Reach out">reach out</a> if you'd like to connect and share ideas</a>.</p>
+    <p>Feel free to <a target="_blank" rel="noopener" href="mailto:alexander.tibbets@gmail.com?subject=%F0%9F%91%8B%20Let%27s%20connect%20and%20talk%20shop" title="Reach out">reach out</a> if you'd like to connect and share ideas.</p>
     
     <br><br>
 
     <div class="social-media" aria-label="Social media links">   
-      <a href="mailto:alexander.tibbets@gmail.com?subject=%F0%9F%91%8B%20Let's%20connect%20and%20talk%20shop" target="_blank" rel="noopener" aria-label="Email Alexander Tibbets"><i class="fa-solid fa-envelope" aria-hidden="true"></i></a>
+      <a href="mailto:alexander.tibbets@gmail.com?subject=%F0%9F%91%8B%20Let%27s%20connect%20and%20talk%20shop" target="_blank" rel="noopener" aria-label="Email Alexander Tibbets"><i class="fa-solid fa-envelope" aria-hidden="true"></i></a>
       <a href="https://www.linkedin.com/in/mrtibbets" target="_blank" rel="noopener" aria-label="Connect on LinkedIn"><i class="fa-brands fa-linkedin-in" aria-hidden="true"></i></a>
       <a href="https://github.com/MRTIBBETS" target="_blank" rel="noopener" aria-label="Follow on GitHub"><i class="fa-brands fa-github" aria-hidden="true"></i></a>
       <a href="https://www.youtube.com/@mrtibbets" target="_blank" rel="noopener" aria-label="Follow on YouTube"><i class="fa-brands fa-youtube" aria-hidden="true"></i></a>


### PR DESCRIPTION
## Summary
- escape single quote in mailto link to avoid HTML parsing issues

## Testing
- `python3 -m py_compile apply_cloudflare_settings.py`


------
https://chatgpt.com/codex/tasks/task_e_685209cbbcbc83218934ecaa472f0d95