### PR TITLE
Fix accessibility and add sitemap links

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,6 +8,9 @@
     <!-- SEO Meta Tags -->
     <title>Page Not Found | Alexander Tibbets</title>
     <meta name="description" content="The page you're looking for doesn't exist.">
+
+    <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
+    <link rel="alternate" type="text/plain" title="Robots" href="/robots.txt">
     
     <!-- Performance Optimizations -->
     <link rel="preload" href="/style.css" as="style">
@@ -29,6 +32,8 @@
     <footer role="contentinfo">
         <div class="copyright">
             © 2025&nbsp;&nbsp;&nbsp;Alexander Tibbets&nbsp;&nbsp;&nbsp;Berkeley
+            · <a href="/sitemap.xml" title="Sitemap">Sitemap</a>
+            · <a href="/robots.txt" title="Robots">Robots</a>
         </div>
     </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <meta name="keywords" content="Alexander Tibbets, Alex Tibbets, website, startups, media technology, marketing, business, Berkeley, California, Duncanville, Dallas, Texas, New York University, NYU, film, video">
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
   <link rel="canonical" href="https://www.alexandertibbets.com">
+  <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
+  <link rel="alternate" type="text/plain" title="Robots" href="/robots.txt">
   
   <!-- GOOGLE SEARCH CONSOLE VERIFICATION -->
   <meta name="google-site-verification" content="google1234567890abcdef" />
@@ -108,6 +110,8 @@
   <footer role="contentinfo">
     <div class="copyright">
       © 2025&nbsp;&nbsp;&nbsp;Alexander Tibbets&nbsp;&nbsp;&nbsp;Berkeley
+      · <a href="/sitemap.xml" title="Sitemap">Sitemap</a>
+      · <a href="/robots.txt" title="Robots">Robots</a>
     </div>
   </footer>
 

--- a/profiles.html
+++ b/profiles.html
@@ -11,6 +11,8 @@
   <meta name="keywords" content="Alexander Tibbets, Alex Tibbets, social media profiles, LinkedIn, GitHub, Twitter, YouTube, Instagram, Facebook, Reddit, ProductHunt, Dev.to, SoundCloud, Apple Music, MixCloud, Bluesky, Bloomberg, Crunchbase, Wikipedia, IFTTT co-founder, startup advisor, Berkeley, California">
   <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">
   <link rel="canonical" href="https://www.alexandertibbets.com/profiles">
+  <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
+  <link rel="alternate" type="text/plain" title="Robots" href="/robots.txt">
   
   <!-- PERFORMANCE OPTIMIZATION: PRECONNECT TO EXTERNAL RESOURCES -->
   <link rel="preconnect" href="https://www.alexandertibbets.com" crossorigin>
@@ -74,7 +76,7 @@
           <span class="platform-name">LinkedIn</span>
         </a>
         <a href="https://www.crunchbase.com/person/alexander-tibbets" target="_blank" rel="noopener" aria-label="Alexander Tibbets on Crunchbase - Business Profile">
-          <img src="/assets/icons/crunchbase.svg" alt="Crunchbase" width="26" height="26" loading="lazy">
+          <img src="/assets/icons/crunchbase.svg" alt="Crunchbase logo" width="26" height="26" loading="lazy">
           <span class="platform-name">Crunchbase</span>
         <a href="https://en.wikipedia.org/wiki/IFTTT" target="_blank" rel="noopener" aria-label="IFTTT on Wikipedia - Company Information">
           <i class="fa-brands fa-wikipedia-w" aria-hidden="true"></i>
@@ -137,7 +139,7 @@
           <i class="fa-brands fa-youtube" aria-hidden="true"></i>
           <span class="platform-name">YouTube</span>
         </a><a href="https://music.apple.com/profile/mrtibbets" target="_blank" rel="noopener" aria-label="Alexander Tibbets on Apple Music - Music Profile">
-          <img src="/assets/icons/apple_music.svg" alt="Apple Music" width="26" height="26" loading="lazy">
+          <img src="/assets/icons/apple_music.svg" alt="Apple Music logo" width="26" height="26" loading="lazy">
           <span class="platform-name">Apple Music</span>
         </a>
         <a href="https://soundcloud.com/mrtibbets" target="_blank" rel="noopener" aria-label="Alexander Tibbets on SoundCloud - Audio Content">
@@ -145,7 +147,7 @@
           <span class="platform-name">SoundCloud</span>
         </a>
         <a href="https://www.mixcloud.com/mrtibbets" target="_blank" rel="noopener" aria-label="Alexander Tibbets on MixCloud - Music Mixes">
-          <img src="/assets/icons/mixcloud.svg" alt="MixCloud" width="26" height="26" loading="lazy">
+          <img src="/assets/icons/mixcloud.svg" alt="MixCloud logo" width="26" height="26" loading="lazy">
           <span class="platform-name">MixCloud</span>
         </a>
       </div>
@@ -155,6 +157,8 @@
   <footer role="contentinfo">
     <div class="copyright">
       © 2025&nbsp;&nbsp;&nbsp;Alexander Tibbets&nbsp;&nbsp;&nbsp;Berkeley
+      · <a href="/sitemap.xml" title="Sitemap">Sitemap</a>
+      · <a href="/robots.txt" title="Robots">Robots</a>
     </div>
   </footer>
 


### PR DESCRIPTION
## Summary
- improve image alt text in `profiles.html`
- link `sitemap.xml` and `robots.txt` in `index.html`, `profiles.html` and `404.html`
- expose sitemap and robots links in page footers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_686d7ddcadf08321b9286b0fcbfd05d8